### PR TITLE
Fixing index page in navigation tiles

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ description: ""
 # gtag: G-RXQ55EFTTH
 # Google analytics tag
 
-remote_theme: ELIXIR-Belgium/elixir-toolkit-theme@1.19.0
+remote_theme: ELIXIR-Belgium/elixir-toolkit-theme@1.19.1
 
 theme_variables:
   theme_color: da366e

--- a/human_biomolecular_data/index.md
+++ b/human_biomolecular_data/index.md
@@ -2,6 +2,6 @@
 title: Human biomolecular data
 ---
 
-{% include section-navigation-tiles.html type="human_biomolecular_data" search=true except="index.md" %}
+{% include section-navigation-tiles.html type="human_biomolecular_data" search=true except="index.md" except="index.md" %}
 
 

--- a/human_biomolecular_data/index.md
+++ b/human_biomolecular_data/index.md
@@ -2,6 +2,6 @@
 title: Human biomolecular data
 ---
 
-{% include section-navigation-tiles.html type="human_biomolecular_data" search=true %}
+{% include section-navigation-tiles.html type="human_biomolecular_data" search=true except="index.md" %}
 
 

--- a/human_clinical_and_health_data/index.md
+++ b/human_clinical_and_health_data/index.md
@@ -2,5 +2,5 @@
 title: Human clinical and health data
 ---
 
-{% include section-navigation-tiles.html type="human_clinical_and_health_data" search=true %}
+{% include section-navigation-tiles.html type="human_clinical_and_health_data" search=true except="index.md" %}
 

--- a/pathogen_characterisation/index.md
+++ b/pathogen_characterisation/index.md
@@ -3,5 +3,5 @@ title: Pathogen characterisation
 ---
 
 
-{% include section-navigation-tiles.html type="pathogen_characterisation" search=true %}
+{% include section-navigation-tiles.html type="pathogen_characterisation" search=true except="index.md" %}
 

--- a/social_and_economic_impact/index.md
+++ b/social_and_economic_impact/index.md
@@ -4,5 +4,5 @@ title: Social and economic impact
 
 
 
-{% include section-navigation-tiles.html type="social_and_economic_impact" search="true" %}
+{% include section-navigation-tiles.html type="social_and_economic_impact" search="true" except="index.md" %}
 


### PR DESCRIPTION
This PR prevents index pages from being listed in the navigation tiles on the section landing pages.