### PR TITLE
link to BY-COVID google doc template

### DIFF
--- a/contribute/google_doc_way.md
+++ b/contribute/google_doc_way.md
@@ -9,7 +9,7 @@ Infectious Diseases Toolkit is hosted on GitHub. We understand, however, that ma
 
 The steps are as follows:
 * Email the editorial team at [idtk-editors@elixir-europe.org](mailto:idtk-editors@elixir-europe.org) to propose a new page or a new section in an existing page. Make sure you keep other contributors in the CC of your email. The editors will create an issue in our GitHub repository to announce your contribution to others.  
-* Use [our google doc template](https://docs.google.com/document/d/1gYS3vjiCIBQv5p3Fn8_d97qfIHRLbwUyMadnkaEGa1I/edit) to write the page and notify the editorial team when you are finished.
+* Use [our google doc template](https://docs.google.com/document/d/1kAYZaimOG6UR9wvTUn2Tzi-0pSO8eOarO-Kxpmg2HRM/edit?usp=sharing) to write the page and notify the editorial team when you are finished.
 * The editors will assign reviewers to your page, who will provide feedback as comments on the shared google doc.
 * Address the reviewers' comments and let the editorial team know, again by mail, that you're finished with revisions.
 * The editors will transfer your page to GitHub and let you know when it is published on the website.


### PR DESCRIPTION
Updated link on `/contribute/google_doc_way` to the template on the BY-COVID folder