### PR TITLE
Update page_metadata.md

### DIFF
--- a/contribute/page_metadata.md
+++ b/contribute/page_metadata.md
@@ -47,7 +47,7 @@ title: Title of the page
 
 * `related_pages`: List here the `page_id` of {{site.title}} pages that you want to display as Related pages, grouped by section.
 
-  If you want pages from the specific section (Pathogen characterisation, Social and economic impact, Human biomolecular data, Human clinical and health data, showcase) to be shown here as Related pages, list their `page_id`. If you want to list multiple related pages, make sure to put them in a list like this: [page_id1, page_id2]. The specific sections allowed in each page are specified in each page template. Please, do not add extra sections in the metadata of the page.
+  If you want pages from the specific section (Pathogen characterisation, Social and economic impact, Human biomolecular data, Human clinical and health data, showcase) to be shown here as Related pages, list their `page_id`. If you want to list multiple related pages, make sure to put them in a list like this: [page_id1, page_id2].  The specific sections allowed in each page are specified in each page template. Please, do not add extra sections in the metadata of the page. If you do not want to add any related pages at the time, just create/leave it as an empty list e.g. `showcase: []`
 
   ```yml
   related_pages: 


### PR DESCRIPTION
To guide the users that the related pages need a list structure always (even if no related pages are given).