### PR TITLE
Change color Heading level 2 to primary (pink)

### DIFF
--- a/_sass/_custom_classes.scss
+++ b/_sass/_custom_classes.scss
@@ -6,7 +6,7 @@ main {
         font-weight: 600;
     }
     h2, .h2-like {
-        color: $blue;
+        color: $primary;
     }
 }
 


### PR DESCRIPTION
After feedback of the style changes, it was pointed out that using the same blue for headings as the links creates confusion for the user what to click on.