### PR TITLE
Change `Regulatory considerations` to `Ethical Legal and Social Issues`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,7 +11,7 @@
 /human_biomolecular_data        @elixir-europe/idtk-editors
 /human_clinical_and_health_data        @elixir-europe/idtk-editors
 /pathogen_characterisation        @elixir-europe/idtk-editors
-/social_and_economic_impact        @elixir-europe/idtk-editors
+/socioeconomic_data        @elixir-europe/idtk-editors
 /national_resources        @elixir-europe/idtk-editors
 /showcase        @elixir-europe/idtk-editors
 

--- a/TEMPLATE_page.md
+++ b/TEMPLATE_page.md
@@ -11,7 +11,7 @@ related_pages:
   showcase: [<!---REPLACE THIS with the page IDs of the showcase pages that you want to list here as related pages--->]
   human_biomolecular_data: [<!---REPLACE THIS with the page IDs of the human_biomolecular_data pages that you want to list here as related pages--->]
   human_clinical_and_health_data: [<!---REPLACE THIS with the page IDs of the human_clinical_and_health_data pages that you want to list here as related pages--->]
-  social_and_economic_impact: [<!---REPLACE THIS with the page IDs of the social_and_economic_impact pages that you want to list here as related pages--->]
+  socioeconomic_data: [<!---REPLACE THIS with the page IDs of the socioeconomic_data pages that you want to list here as related pages--->]
   pathogen_characterisation: [<!---REPLACE THIS with the page IDs of the pathogen_characterisation pages that you want to list here as related pages--->]
 training:
   - name:

--- a/_config.yml
+++ b/_config.yml
@@ -50,10 +50,10 @@ defaults:
 
   -
     scope:
-      path: "social_and_economic_impact"
+      path: "socioeconomic_data"
       type: "pages"
     values:
-      type: social_and_economic_impact
+      type: socioeconomic_data
     
   -
     scope:

--- a/_data/sidebars/main.yml
+++ b/_data/sidebars/main.yml
@@ -21,26 +21,27 @@ subitems:
         url: /pathogen_characterisation/quality_control
       - title: Regulatory considerations
         url: /pathogen_characterisation/regulatory_considerations
-  - title: Social and economic impact
+
+  - title: Socioeconomic data
     image_url: /assets/img/section-icons/users-viewfinder-thin.svg
-    url: /social_and_economic_impact/
+    url: /socioeconomic_data/
     subitems:
       - title: Attributing credit
-        url: /social_and_economic_impact/attributing_credit
+        url: /socioeconomic_data/attributing_credit
       - title: Data analysis
-        url: /social_and_economic_impact/data_analysis
+        url: /socioeconomic_data/data_analysis
       - title: Data communication
-        url: /social_and_economic_impact/data_communication
+        url: /socioeconomic_data/data_communication
       - title: Data description
-        url: /social_and_economic_impact/data_description
+        url: /socioeconomic_data/data_description
       - title: Data sources
-        url: /social_and_economic_impact/data_sources
+        url: /socioeconomic_data/data_sources
       - title: Provenance
-        url: /social_and_economic_impact/provenance
+        url: /socioeconomic_data/provenance
       - title: Quality control
-        url: /social_and_economic_impact/quality_control
+        url: /socioeconomic_data/quality_control
       - title: Regulatory considerations
-        url: /social_and_economic_impact/regulatory_considerations
+        url: /socioeconomic_data/regulatory_considerations
 
   - title: Human biomolecular data
     image_url: /assets/img/section-icons/dna-person-thin.svg

--- a/_data/sidebars/main.yml
+++ b/_data/sidebars/main.yml
@@ -19,8 +19,8 @@ subitems:
         url: /pathogen_characterisation/provenance
       - title: Quality control
         url: /pathogen_characterisation/quality_control
-      - title: Regulatory considerations
-        url: /pathogen_characterisation/regulatory_considerations
+      - title: Ethical Legal and Social Issues
+        url: /pathogen_characterisation/ethical-legal-and-social-issues
 
   - title: Socioeconomic data
     image_url: /assets/img/section-icons/users-viewfinder-thin.svg
@@ -40,8 +40,8 @@ subitems:
         url: /socioeconomic_data/provenance
       - title: Quality control
         url: /socioeconomic_data/quality_control
-      - title: Regulatory considerations
-        url: /socioeconomic_data/regulatory_considerations
+      - title: Ethical Legal and Social Issues
+        url: /socioeconomic_data/ethical-legal-and-social-issues
 
   - title: Human biomolecular data
     image_url: /assets/img/section-icons/dna-person-thin.svg
@@ -61,8 +61,8 @@ subitems:
         url: /human_biomolecular_data/provenance
       - title: Quality control
         url: /human_biomolecular_data/quality_control
-      - title: Regulatory considerations
-        url: /human_biomolecular_data/regulatory_considerations
+      - title: Ethical Legal and Social Issues
+        url: /human_biomolecular_data/ethical-legal-and-social-issues
 
   - title: Human clinical and health data
     image_url: /assets/img/section-icons/hospital-user-thin.svg
@@ -82,8 +82,8 @@ subitems:
         url: /human_clinical_and_health_data/provenance
       - title: Quality control
         url: /human_clinical_and_health_data/quality_control
-      - title: Regulatory considerations
-        url: /human_clinical_and_health_data/regulatory_considerations
+      - title: Ethical Legal and Social Issues
+        url: /human_clinical_and_health_data/ethical-legal-and-social-issues
 
   - title: Showcase
     hr: true

--- a/contribute/editorial_board_guide.md
+++ b/contribute/editorial_board_guide.md
@@ -16,7 +16,7 @@ This process is sketched below.
 
 ### Overview of the file structure in GitHub
 
-The content of the website is built up using markdown files found in the [root](https://github.com/elixir-europe/infectious-diseases-toolkit) of the repository, spread in subdirectories according to the website section (human_biomolecular_data, human_clinical_and_health_data, contribute, social_and_economic_impact, ...).
+The content of the website is built up using markdown files found in the [root](https://github.com/elixir-europe/infectious-diseases-toolkit) of the repository, spread in subdirectories according to the website section (human_biomolecular_data, human_clinical_and_health_data, contribute, socioeconomic_data, ...).
 
 ### Markdown file naming
 
@@ -94,7 +94,7 @@ To generate a new page it is sufficient to simply copy the TEMPLATE file and ren
 
 3. Select and copy all the content.
 
-4. Go to the main section were you want to make the new page (human_biomolecular_data, human_clinical_and_health_data, contribute, social_and_economic_impact, ...), in our example this will be in */showcase/*. Click on `Add file` on the right followed up by `Create new file`.
+4. Go to the main section were you want to make the new page (human_biomolecular_data, human_clinical_and_health_data, contribute, socioeconomic_data, ...), in our example this will be in */showcase/*. Click on `Add file` on the right followed up by `Create new file`.
     {% include image.html file="create_new_file_github.png" inline=true alt="Create new file GitHub." %}
 
 5. Paste the copied content from the template.
@@ -211,7 +211,7 @@ An overview of all Infectious Diseases Toolkit pages and their `page_id` can be 
 ```yml
 related_pages: 
    pathogen_characterisation: [page_id1, page_id2]
-   social_and_economic_impact: [page_id1, page_id2]
+   socioeconomic_data: [page_id1, page_id2]
    human_biomolecular_data: [page_id1, page_id2]
    human_clinical_and_health_data: [page_id1, page_id2]
    showcase: [page_id1, page_id2]

--- a/contribute/editors_checklist.md
+++ b/contribute/editors_checklist.md
@@ -17,7 +17,7 @@ summary: Checklist for editors before approving and merging a pull request (PR).
    * `affiliation`
    * `coordinators`(only used in national pages + they must be listed as `contributors` as well)
    * `resources`
-5. Items in the "[Tools and resources spreadsheet](https://docs.google.com/spreadsheets/d/13tqfSbgivokfEkxGXPRFShVhCmO4VuTQRe4uQgJOMbc)" are tagged with already existing (merged) `page_id` from "Pathogen characterisation, Social and economic impact, Human biomolecular data, Human clinical and health data, Showcase" and that Bert has been informed of the changes.
+5. Items in the "[Tools and resources spreadsheet](https://docs.google.com/spreadsheets/d/13tqfSbgivokfEkxGXPRFShVhCmO4VuTQRe4uQgJOMbc)" are tagged with already existing (merged) `page_id` from "Pathogen characterisation, Socioeconomic data, Human biomolecular data, Human clinical and health data, Showcase" and that Bert has been informed of the changes.
 6. The content is within the scope of the Infectious Diseases Toolkit (prevent overlap with the [RDMkit](https://rdmkit.elixir-europe.org/) and link towards it instead), conforms to the appropriate templates and the [style](/contribute/style_guide).
 7. There are no [copyright](/contribute/copyright) issues related to the content of the page.
 8. The contributors implemented the requested changes.

--- a/contribute/markdown_cheat_sheet.md
+++ b/contribute/markdown_cheat_sheet.md
@@ -328,7 +328,7 @@ An overview of all Infectious Diseases Toolkit pages (belonging to the sections 
 ```yml
 related_pages: 
    pathogen_characterisation: [page_id1, page_id2]
-   social_and_economic_impact: [page_id1, page_id2]
+   socioeconomic_data: [page_id1, page_id2]
    human_biomolecular_data: [page_id1, page_id2]
    human_clinical_and_health_data: [page_id1, page_id2]
    showcase: [page_id1, page_id2]

--- a/contribute/page_metadata.md
+++ b/contribute/page_metadata.md
@@ -47,12 +47,12 @@ title: Title of the page
 
 * `related_pages`: List here the `page_id` of {{site.title}} pages that you want to display as Related pages, grouped by section.
 
-  If you want pages from the specific section (Pathogen characterisation, Social and economic impact, Human biomolecular data, Human clinical and health data, showcase) to be shown here as Related pages, list their `page_id`. If you want to list multiple related pages, make sure to put them in a list like this: [page_id1, page_id2].  The specific sections allowed in each page are specified in each page template. Please, do not add extra sections in the metadata of the page. If you do not want to add any related pages at the time, just create/leave it as an empty list e.g. `showcase: []`
+  If you want pages from the specific section (Pathogen characterisation, Socioeconomic data, Human biomolecular data, Human clinical and health data, showcase) to be shown here as Related pages, list their `page_id`. If you want to list multiple related pages, make sure to put them in a list like this: [page_id1, page_id2].  The specific sections allowed in each page are specified in each page template. Please, do not add extra sections in the metadata of the page. If you do not want to add any related pages at the time, just create/leave it as an empty list e.g. `showcase: []`
 
   ```yml
   related_pages: 
    - pathogen_characterisation: [page_id1, page_id2]
-   - social_and_economic_impact: [page_id1, page_id2]
+   - socioeconomic_data: [page_id1, page_id2]
    - human_biomolecular_data: [page_id1, page_id2]
    - human_clinical_and_health_data: [page_id1, page_id2]
    - showcase: [page_id1, page_id2]

--- a/human_biomolecular_data/attributing_credit.md
+++ b/human_biomolecular_data/attributing_credit.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/human_biomolecular_data/data_analysis.md
+++ b/human_biomolecular_data/data_analysis.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/human_biomolecular_data/data_communication.md
+++ b/human_biomolecular_data/data_communication.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/human_biomolecular_data/data_description.md
+++ b/human_biomolecular_data/data_description.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/human_biomolecular_data/data_sources.md
+++ b/human_biomolecular_data/data_sources.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/human_biomolecular_data/ethical-legal-and-social-issues.md
+++ b/human_biomolecular_data/ethical-legal-and-social-issues.md
@@ -1,8 +1,8 @@
 ---
-title: Regulatory considerations
+title: Ethical Legal and Social Issues
 description: Legal and ethical aspects and how to deal with them
 contributors: []
-page_id: sed_regulatory_considerations
+page_id: hbd_elsi
 rdmkit:
   - name:
     url:

--- a/human_biomolecular_data/provenance.md
+++ b/human_biomolecular_data/provenance.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/human_biomolecular_data/quality_control.md
+++ b/human_biomolecular_data/quality_control.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/human_biomolecular_data/regulatory_considerations.md
+++ b/human_biomolecular_data/regulatory_considerations.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/human_clinical_and_health_data/attributing_credit.md
+++ b/human_clinical_and_health_data/attributing_credit.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/human_clinical_and_health_data/data_analysis.md
+++ b/human_clinical_and_health_data/data_analysis.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/human_clinical_and_health_data/data_communication.md
+++ b/human_clinical_and_health_data/data_communication.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/human_clinical_and_health_data/data_description.md
+++ b/human_clinical_and_health_data/data_description.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/human_clinical_and_health_data/data_sources.md
+++ b/human_clinical_and_health_data/data_sources.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/human_clinical_and_health_data/ethical-legal-and-social-issues.md
+++ b/human_clinical_and_health_data/ethical-legal-and-social-issues.md
@@ -1,8 +1,8 @@
 ---
-title: Regulatory considerations
+title: Ethical Legal and Social Issues
 description: Legal and ethical aspects and how to deal with them
 contributors: []
-page_id: pc_regulatory_considerations
+page_id: hchd_elsi
 rdmkit:
   - name:
     url:

--- a/human_clinical_and_health_data/provenance.md
+++ b/human_clinical_and_health_data/provenance.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/human_clinical_and_health_data/quality_control.md
+++ b/human_clinical_and_health_data/quality_control.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/human_clinical_and_health_data/regulatory_considerations.md
+++ b/human_clinical_and_health_data/regulatory_considerations.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/pathogen_characterisation/attributing_credit.md
+++ b/pathogen_characterisation/attributing_credit.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/pathogen_characterisation/data_analysis.md
+++ b/pathogen_characterisation/data_analysis.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/pathogen_characterisation/data_communication.md
+++ b/pathogen_characterisation/data_communication.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/pathogen_characterisation/data_description.md
+++ b/pathogen_characterisation/data_description.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/pathogen_characterisation/data_sources.md
+++ b/pathogen_characterisation/data_sources.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/pathogen_characterisation/ethical-legal-and-social-issues.md
+++ b/pathogen_characterisation/ethical-legal-and-social-issues.md
@@ -1,8 +1,8 @@
 ---
-title: Regulatory considerations
+title: Ethical Legal and Social Issues
 description: Legal and ethical aspects and how to deal with them
 contributors: []
-page_id: hbd_regulatory_considerations
+page_id: pc_elsi
 rdmkit:
   - name:
     url:

--- a/pathogen_characterisation/provenance.md
+++ b/pathogen_characterisation/provenance.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/pathogen_characterisation/quality_control.md
+++ b/pathogen_characterisation/quality_control.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/pathogen_characterisation/regulatory_considerations.md
+++ b/pathogen_characterisation/regulatory_considerations.md
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/showcase/TEMPLATE_showcase.md
+++ b/showcase/TEMPLATE_showcase.md
@@ -7,7 +7,7 @@ affiliations: [<!---REPLACE THIS with comma separated list of affiliations. Coun
 page_id: <!---REPLACE THIS with a shortened page name, with small letters and spaces, or an acronym in capital and small letters--->
 related_pages: 
   pathogen_characterisation: [<!---REPLACE THIS with the page IDs of the pathogen_characterisation pages that you want to list here as related pages--->]
-  social_and_economic_impact: [<!---REPLACE THIS with the page IDs of the social_and_economic_impact pages that you want to list here as related pages--->]
+  socioeconomic_data: [<!---REPLACE THIS with the page IDs of the socioeconomic_data pages that you want to list here as related pages--->]
   human_biomolecular_data: [<!---REPLACE THIS with the page IDs of the human_biomolecular_data pages that you want to list here as related pages--->]
   human_clinical_and_health_data: [<!---REPLACE THIS with the page IDs of the human_clinical_and_health_data pages that you want to list here as related pages--->]  
 training:

--- a/social_and_economic_impact/index.md
+++ b/social_and_economic_impact/index.md
@@ -1,8 +1,0 @@
----
-title: Social and economic impact
----
-
-
-
-{% include section-navigation-tiles.html type="social_and_economic_impact" search="true" except="index.md" %}
-

--- a/socioeconomic_data/attributing_credit.md
+++ b/socioeconomic_data/attributing_credit.md
@@ -2,7 +2,7 @@
 title: Attributing credit
 description: Referencing your sources (citations and recognition of contributions)
 contributors: []
-page_id: sei_attributing_credit
+page_id: sed_attributing_credit
 rdmkit:
   - name:
     url:
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/socioeconomic_data/data_analysis.md
+++ b/socioeconomic_data/data_analysis.md
@@ -1,8 +1,8 @@
 ---
-title: Provenance
-description: Tracking data and analysis steps
+title: Data analysis
+description: Generic workflows for different data types
 contributors: []
-page_id: sei_provenance
+page_id: sed_data_analysis
 rdmkit:
   - name:
     url:
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/socioeconomic_data/data_communication.md
+++ b/socioeconomic_data/data_communication.md
@@ -2,7 +2,7 @@
 title: Data communication
 description: Producing visualisations and reports
 contributors: []
-page_id: sei_data_communication
+page_id: sed_data_communication
 rdmkit:
   - name:
     url:
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/socioeconomic_data/data_description.md
+++ b/socioeconomic_data/data_description.md
@@ -2,7 +2,7 @@
 title: Data description
 description: Finding (meta)data standards and documentation
 contributors: []
-page_id: sei_data_description
+page_id: sed_data_description
 rdmkit:
   - name:
     url:
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/socioeconomic_data/data_sources.md
+++ b/socioeconomic_data/data_sources.md
@@ -2,7 +2,7 @@
 title: Data sources
 description: Finding and sharing data for social and economic impact related data sources.
 contributors: []
-page_id: sei_data_sources
+page_id: sed_data_sources
 rdmkit:
   - name:
     url:
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/socioeconomic_data/ethical-legal-and-social-issues.md
+++ b/socioeconomic_data/ethical-legal-and-social-issues.md
@@ -1,8 +1,8 @@
 ---
-title: Regulatory considerations
+title: Ethical Legal and Social Issues
 description: Legal and ethical aspects and how to deal with them
 contributors: []
-page_id: hchd_regulatory_considerations
+page_id: sed_elsi
 rdmkit:
   - name:
     url:

--- a/socioeconomic_data/index.md
+++ b/socioeconomic_data/index.md
@@ -1,0 +1,8 @@
+---
+title: Socioeconomic data
+---
+
+
+
+{% include section-navigation-tiles.html type="socioeconomic_data" search="true" except="index.md" %}
+

--- a/socioeconomic_data/provenance.md
+++ b/socioeconomic_data/provenance.md
@@ -1,8 +1,8 @@
 ---
-title: Quality control
-description: Tools and methods to assess quality
+title: Provenance
+description: Tracking data and analysis steps
 contributors: []
-page_id: sei_quality_control
+page_id: sed_provenance
 rdmkit:
   - name:
     url:
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/socioeconomic_data/quality_control.md
+++ b/socioeconomic_data/quality_control.md
@@ -1,8 +1,8 @@
 ---
-title: Regulatory considerations
-description: Legal and ethical aspects and how to deal with them
+title: Quality control
+description: Tools and methods to assess quality
 contributors: []
-page_id: sei_regulatory_considerations
+page_id: sed_quality_control
 rdmkit:
   - name:
     url:
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:

--- a/socioeconomic_data/regulatory_considerations.md
+++ b/socioeconomic_data/regulatory_considerations.md
@@ -1,8 +1,8 @@
 ---
-title: Data analysis
-description: Generic workflows for different data types
+title: Regulatory considerations
+description: Legal and ethical aspects and how to deal with them
 contributors: []
-page_id: sei_data_analysis
+page_id: sed_regulatory_considerations
 rdmkit:
   - name:
     url:
@@ -10,7 +10,7 @@ related_pages:
   showcase: []
   human_biomolecular_data: []
   human_clinical_and_health_data: []
-  social_and_economic_impact: []
+  socioeconomic_data: []
   pathogen_characterisation: []
 training:
   - name:


### PR DESCRIPTION
This will close #116 ans #72.

I took now `section_elsi` as page_id, is this ok? or do we go for the long one? 

We might want to add the acronym in the description of the page. 

**WARNING: Merge this PR after #117 is merged**