### PR TITLE
update review pull requests

### DIFF
--- a/contribute/editorial-board-guide.md
+++ b/contribute/editorial-board-guide.md
@@ -43,7 +43,7 @@ More information about these topics can be found in the GitHub documentation:
 
 ## Review pull requests
 
-If contributors make a pull request to make changes, by default the editors that are responsible for files that will be changed by the PR will be assigned and notified. All PR should be assigned to one of the editors. Before merging a PR, keywords and tags for the page as well as the tools and resources should be checked and assigned according to the established tagging system.
+If contributors make a pull request to make changes, by default the editors that are responsible for files that will be changed by the PR will be assigned and notified. All PR should be assigned to one of the editors. Before merging a PR, tags for the page as well as the tools and resources should be checked and assigned according to the established tagging system. When approving a PR, the editor should also merge it. 
   
 ## Link a pull request to an issue
 


### PR DESCRIPTION
Adding explicit mention that who reviews and approves a PR also merges it.
Also removing `keywords` since it does not apply anymore