### PR TITLE
Hide contribute pages in search

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,6 +45,7 @@ defaults:
       type: "pages"
     values:
       sidebar: contribute
+      search_exclude: true
   -
     scope:
       path: "pathogen-characterisation"


### PR DESCRIPTION
Currently when one types in 'metadata' in the search box, the  "page metadata" page pops up as first result, which will be not the page one expects if he is looking for infectious diseases content.

![Screenshot from 2023-03-10 17-11-28](https://user-images.githubusercontent.com/44875756/224366424-c89ef124-1f57-46c9-be7c-9abedd949f98.png)

One can assume that the average user is not interested in the contribute pages and that those are only relevant for contributors.

This PR solves this