### PR TITLE
Make the contact page email address a link

### DIFF
--- a/about/contact.md
+++ b/about/contact.md
@@ -2,4 +2,4 @@
 title: Contact
 ---
 
-For questions and general enquiries please contact us at idtk-editors@elixir-europe.org.
+For questions and general enquiries, please contact us at [idtk-editors@elixir-europe.org](mailto:idtk-editors@elixir-europe.org).


### PR DESCRIPTION
The contact address is just plain text at the moment.