### PR TITLE
Hide pages from search and overview

### DIFF
--- a/contribute/editorial-board-guide.md
+++ b/contribute/editorial-board-guide.md
@@ -1,6 +1,7 @@
 ---
 title: Editorial board guide
 summary: This guide is there to help editors.
+search_exclude: true
 ---
 
 ## All you need to know about this GitHub repository

--- a/contribute/editors-checklist.md
+++ b/contribute/editors-checklist.md
@@ -1,6 +1,7 @@
 ---
 title: Editors checklist
 summary: Checklist for editors before approving and merging a pull request (PR).
+search_exclude: true
 ---
 
 ## Before approving and merging a pull request (PR), the editors must check that

--- a/contribute/github-way.md
+++ b/contribute/github-way.md
@@ -1,5 +1,6 @@
 ---
 title: GitHub way
+search_exclude: true
 ---
 
 

--- a/contribute/google-doc-way.md
+++ b/contribute/google-doc-way.md
@@ -1,5 +1,6 @@
 ---
 title: Google doc way
+search_exclude: true
 ---
 
 

--- a/contribute/index.md
+++ b/contribute/index.md
@@ -1,5 +1,6 @@
 ---
 title: How to contribute to the Infectious Diseases Toolkit website
+search_exclude: true
 ---
 
 

--- a/contribute/page-metadata.md
+++ b/contribute/page-metadata.md
@@ -1,5 +1,6 @@
 ---
 title: Page metadata
+search_exclude: true
 ---
 
 

--- a/contribute/preview-changes.md
+++ b/contribute/preview-changes.md
@@ -1,6 +1,7 @@
 ---
 title: Preview changes
 summary: Use your own fork to preview changes on the website.
+search_exclude: true
 ---
 
 ## Introduction

--- a/contribute/style-guide.md
+++ b/contribute/style-guide.md
@@ -1,5 +1,6 @@
 ---
 title: Style guide
+search_exclude: true
 ---
 
 In general, we follow the European Commission's [Web Writing Style Guide](https://wikis.ec.europa.eu/display/WEBGUIDE/02.+Web+writing+guidelines), and the more detailed [English Style Guide](https://commission.europa.eu/system/files/2023-01/styleguide_english_dgt_en.pdf). Below are the points that you might find most useful, though, and that relate particularly to the Infectious Diseases Toolkit.

--- a/contribute/tool-resource-update.md
+++ b/contribute/tool-resource-update.md
@@ -1,6 +1,7 @@
 ---
 title: Add new tool or resource
 summary: How to add a tool or resource to Infectious diseases toolkit
+search_exclude: true
 ---
 
 ## Way of working

--- a/contribute/website-overview.md
+++ b/contribute/website-overview.md
@@ -1,5 +1,6 @@
 ---
 title: List of page IDs
+search_exclude: true
 ---
 
 {% include pageids-overview.html sidebar="main" %}

--- a/contribute/working-with-git.md
+++ b/contribute/working-with-git.md
@@ -1,5 +1,6 @@
 ---
 title: Working with git
+search_exclude: true
 ---
 
 

--- a/human-biomolecular-data/attributing-credit.md
+++ b/human-biomolecular-data/attributing-credit.md
@@ -3,6 +3,7 @@ title: Attributing credit
 description: Referencing your sources (citations and recognition of contributions)
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: hbd_provenance 
 rdmkit:
   - name:

--- a/human-biomolecular-data/data-communication.md
+++ b/human-biomolecular-data/data-communication.md
@@ -3,6 +3,7 @@ title: Data communication
 description: Producing visualisations and reports
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: hbd_data_communication
 rdmkit:
   - name:

--- a/human-biomolecular-data/data-description.md
+++ b/human-biomolecular-data/data-description.md
@@ -3,6 +3,7 @@ title: Data description
 description: Finding (meta)data standards and documentation
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: hbd_data_description
 rdmkit:
   - name:

--- a/human-biomolecular-data/ethical-legal-and-social-issues.md
+++ b/human-biomolecular-data/ethical-legal-and-social-issues.md
@@ -3,6 +3,7 @@ title: Ethical Legal and Social Issues
 description: Legal and ethical aspects and how to deal with them
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: hbd_elsi
 rdmkit:
   - name:

--- a/human-biomolecular-data/provenance.md
+++ b/human-biomolecular-data/provenance.md
@@ -3,6 +3,7 @@ title: Provenance
 description: Tracking data and analysis steps
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: hbd_provenance
 rdmkit:
   - name:

--- a/human-biomolecular-data/quality-control.md
+++ b/human-biomolecular-data/quality-control.md
@@ -3,6 +3,7 @@ title: Quality control
 description: Tools and methods to assess quality
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: hbd_quality_control
 rdmkit:
   - name:

--- a/human-clinical-and-health-data/attributing-credit.md
+++ b/human-clinical-and-health-data/attributing-credit.md
@@ -3,6 +3,7 @@ title: Attributing credit
 description: Referencing your sources (citations and recognition of contributions)
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: hchd_attributing_credit
 rdmkit:
   - name:

--- a/human-clinical-and-health-data/data-analysis.md
+++ b/human-clinical-and-health-data/data-analysis.md
@@ -3,6 +3,7 @@ title: Data analysis
 description: Generic workflows for different data types
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: hchd_data_analysis
 rdmkit:
   - name:

--- a/human-clinical-and-health-data/data-communication.md
+++ b/human-clinical-and-health-data/data-communication.md
@@ -3,6 +3,7 @@ title: Data communication
 description: Producing visualisations and reports
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: hchd_data_communication
 rdmkit:
   - name:

--- a/human-clinical-and-health-data/data-description.md
+++ b/human-clinical-and-health-data/data-description.md
@@ -3,6 +3,7 @@ title: Data description
 description: Finding (meta)data standards and documentation
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: hchd_data_description
 rdmkit:
   - name:

--- a/human-clinical-and-health-data/data-sources.md
+++ b/human-clinical-and-health-data/data-sources.md
@@ -3,6 +3,7 @@ title: Data sources
 description: Finding and sharing data for human clinical and health data related data sources.
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: hchd_data_sources
 rdmkit:
   - name:

--- a/human-clinical-and-health-data/ethical-legal-and-social-issues.md
+++ b/human-clinical-and-health-data/ethical-legal-and-social-issues.md
@@ -3,6 +3,7 @@ title: Ethical Legal and Social Issues
 description: Legal and ethical aspects and how to deal with them
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: hchd_elsi
 rdmkit:
   - name:

--- a/human-clinical-and-health-data/quality-control.md
+++ b/human-clinical-and-health-data/quality-control.md
@@ -3,6 +3,7 @@ title: Quality control
 description: Tools and methods to assess quality
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: hchd_quality_control
 rdmkit:
   - name:

--- a/pathogen-characterisation/attributing-credit.md
+++ b/pathogen-characterisation/attributing-credit.md
@@ -3,6 +3,7 @@ title: Attributing credit
 description: Referencing your sources (citations and recognition of contributions)
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: pc_attributing_credit
 rdmkit:
   - name:

--- a/pathogen-characterisation/data-analysis.md
+++ b/pathogen-characterisation/data-analysis.md
@@ -3,6 +3,7 @@ title: Data analysis
 description: Generic workflows for different data types
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: pc_data_analysis
 rdmkit:
   - name:

--- a/pathogen-characterisation/data-communication.md
+++ b/pathogen-characterisation/data-communication.md
@@ -3,6 +3,7 @@ title: Data communication
 description: Producing visualisations and reports
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: pc_data_communication
 rdmkit:
   - name:

--- a/pathogen-characterisation/data-description.md
+++ b/pathogen-characterisation/data-description.md
@@ -3,6 +3,7 @@ title: Data description
 description: Finding (meta)data standards and documentation
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: pc_data_description
 rdmkit:
   - name:

--- a/pathogen-characterisation/data-sources.md
+++ b/pathogen-characterisation/data-sources.md
@@ -3,6 +3,7 @@ title: Data sources
 description: Finding and sharing data for pathogen characterisation related data sources.
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: pc_data_sources
 rdmkit:
   - name:

--- a/pathogen-characterisation/ethical-legal-and-social-issues.md
+++ b/pathogen-characterisation/ethical-legal-and-social-issues.md
@@ -3,6 +3,7 @@ title: Ethical Legal and Social Issues
 description: Legal and ethical aspects and how to deal with them
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: pc_elsi
 rdmkit:
   - name:

--- a/pathogen-characterisation/provenance.md
+++ b/pathogen-characterisation/provenance.md
@@ -3,6 +3,7 @@ title: Provenance
 description: Tracking data and analysis steps
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: pc_provenance
 rdmkit:
   - name:

--- a/pathogen-characterisation/quality-control.md
+++ b/pathogen-characterisation/quality-control.md
@@ -3,6 +3,7 @@ title: Quality control
 description: Tools and methods to assess quality
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: pc_quality_control
 rdmkit:
   - name:

--- a/socioeconomic-data/attributing-credit.md
+++ b/socioeconomic-data/attributing-credit.md
@@ -3,6 +3,7 @@ title: Attributing credit
 description: Referencing your sources (citations and recognition of contributions)
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: sed_attributing_credit
 rdmkit:
   - name:

--- a/socioeconomic-data/data-analysis.md
+++ b/socioeconomic-data/data-analysis.md
@@ -3,6 +3,7 @@ title: Data analysis
 description: Generic workflows for different data types
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: sed_data_analysis
 rdmkit:
   - name:

--- a/socioeconomic-data/data-communication.md
+++ b/socioeconomic-data/data-communication.md
@@ -3,6 +3,7 @@ title: Data communication
 description: Producing visualisations and reports
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: sed_data_communication
 rdmkit:
   - name:

--- a/socioeconomic-data/data-description.md
+++ b/socioeconomic-data/data-description.md
@@ -3,6 +3,7 @@ title: Data description
 description: Finding (meta)data standards and documentation
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: sed_data_description
 rdmkit:
   - name:

--- a/socioeconomic-data/ethical-legal-and-social-issues.md
+++ b/socioeconomic-data/ethical-legal-and-social-issues.md
@@ -3,6 +3,7 @@ title: Ethical Legal and Social Issues
 description: Legal and ethical aspects and how to deal with them
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: sed_elsi
 rdmkit:
   - name:

--- a/socioeconomic-data/provenance.md
+++ b/socioeconomic-data/provenance.md
@@ -3,6 +3,7 @@ title: Provenance
 description: Tracking data and analysis steps
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: sed_provenance
 rdmkit:
   - name:

--- a/socioeconomic-data/quality-control.md
+++ b/socioeconomic-data/quality-control.md
@@ -3,6 +3,7 @@ title: Quality control
 description: Tools and methods to assess quality
 contributors: []
 no_robots: true
+search_exclude: true
 page_id: sed_quality_control
 rdmkit:
   - name:


### PR DESCRIPTION
This is related to the pathogen indexing. We only want them to index our pages with content.

since `search_exclude: true` also affects the overview tiles, only tiles with content will be visible: 

![Screenshot from 2023-10-12 20-26-27](https://github.com/elixir-europe/infectious-diseases-toolkit/assets/44875756/2a9ca04d-a78c-451f-88c4-bf5966208cb5)
