### PR TITLE
Less spacing in sidebar

### DIFF
--- a/_sass/_bootstrap_variables.scss
+++ b/_sass/_bootstrap_variables.scss
@@ -33,6 +33,7 @@ $card-border-width: 0;
 $input-group-addon-bg: $blue-x;
 $input-bg: $light;
 $input-border-width: 0;
+$btn-padding-y: 0.25rem;
 $btn-border-radius-sm: $border-radius;
 
 // Links


### PR DESCRIPTION
![image](https://github.com/elixir-europe/infectious-diseases-toolkit/assets/44875756/cf7f59af-f53b-4eba-bb80-9bce27fac51b)

This will prevent the scrollbar to appear as quick as it does now