### PR TITLE
Remove ampersands and add bullet points from the About page

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -2,18 +2,19 @@
 title: About
 ---
 ## What is the Infectious Diseases Toolkit?
-The Infectious Diseases Toolkit (IDTk) is a community effort to expose best practices and showcase solutions to data challenges affecting the response to infectious diseases outbreaks. It was created as part of the [BY-COVID]( https://by-covid.org/) project.
+The Infectious Diseases Toolkit (IDTk) provides best practices and solutions to data challenges that affect the response to infectious diseases outbreaks. It is a community effort, which was created as part of the [BY-COVID]( https://by-covid.org/) project.
 
 ## What are the aims of IDTk?
-The IDTk provides a platform for knowledge exchange to enable data mobilisation, connection & exposure, and use & analysis.
+The IDTk provides a platform for knowledge exchange to enable data mobilisation, connection and exposure, and use and analysis.
+
 By providing a compilation of past and present efforts, collecting country specific strategies and distilling contextualised best practices from previous responses, IDTk aims to enhance infectious diseases outbreak preparedness.
 
 ## What does the IDTk offer?
-General guidelines for data handling, analysis and visualisations in the context of infectious diseases. Guidelines are divided in categories and represent the contribution of communities from each domain.
-Tools, standards and overall resources that are contextually presented, including considerations for their need and use. 
-A collection of showcases. These are examples that combine and apply multiple resources (e.g. standards, tools, workflows) in the response to one or more infectious diseases.
-National resources pages in which country specific experiences, examples and resources are shared.
-The IDTk strives to connect users with the appropriate resources. A collection of tools, resources and training is offered, in addition to signposting external resources.
+ * General guidelines for data handling, analysis and visualisations in the context of infectious diseases. The guidelines are divided in categories and represent the contribution of communities from each domain.
+ * Tools, standards and overall resources that are contextually presented, including considerations for their need and use. 
+ * A collection of showcases. These are examples that combine and apply multiple resources (e.g. standards, tools, workflows) in the response to one or more infectious diseases.
+ * National resources pages in which country specific experiences, examples and resources are shared.
+ * The IDTk strives to connect users with the appropriate resources. A collection of tools, resources and training is offered, in addition to signposting external resources.
  
 ## Funding acknowledgement
 BY-COVID project received funding from the European Union’s Horizon Europe Research and Innovation Programme under grant agreement number 101046203. Please check our [Support page](/about/support) for further information on funding and contributing projects.


### PR DESCRIPTION
We don't use ampersands in normal text. These have been removed and the "What does the IDTk offer?" section has been broken into bullet points. I've also simplified the first sentence.